### PR TITLE
Change username to e-mail and omit public_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Asynchronous Python client for the Autarco Inverters.
 
 A python package with which you can read the data of your [Autarco][autarco]
 Inverter(s). This is done by making a request to the [My Autarco][my-autarco]
-platform, for this you will need the `public_key`, `username` and `password`.
+platform, for this you will need the `email` and `password`.
 The data on the platform is updated every 5 minutes.
 
 ### Public key
@@ -49,11 +49,10 @@ from autarco import Autarco
 async def main():
     """Show example on getting Autarco data."""
     async with Autarco(
-        public_key="key",
-        username="autarco@test.com",
+        email="autarco@example.com",
         password="password",
     ) as client:
-        inverters = await client.all_inverter()
+        inverters = await client.all_inverters()
         solar = await client.solar()
         account = await client.account()
         print(inverters)
@@ -174,7 +173,7 @@ SOFTWARE.
 [code-quality]: https://lgtm.com/projects/g/klaasnicolaas/python-autarco/context:python
 [commits-shield]: https://img.shields.io/github/commit-activity/y/klaasnicolaas/python-autarco.svg
 [commits-url]: https://github.com/klaasnicolaas/python-autarco/commits/master
-[codecov-shield]: https://codecov.io/gh/klaasnicolaas/python-autarco/branch/master/graph/badge.svg?token=JM72C3T2AT
+[codecov-shield]: https://codecov.io/gh/klaasnicolaas/python-autarco/branch/main/graph/badge.svg?token=JM72C3T2AT
 [codecov-url]: https://codecov.io/gh/klaasnicolaas/python-autarco
 [forks-shield]: https://img.shields.io/github/forks/klaasnicolaas/python-autarco.svg
 [forks-url]: https://github.com/klaasnicolaas/python-autarco/network/members

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ The data on the platform is updated every 5 minutes.
 You can find this in the url after logging in,
 example: `https://my.autarco.com/site/{public_key}`
 
+Or by using the `get_public_key` method, that will
+return your key.
+
 ## Installation
 
 ```bash
@@ -49,12 +52,14 @@ from autarco import Autarco
 async def main():
     """Show example on getting Autarco data."""
     async with Autarco(
-        email="autarco@example.com",
+        email="test@autarco.com",
         password="password",
     ) as client:
-        inverters = await client.all_inverters()
-        solar = await client.solar()
-        account = await client.account()
+        public_key = await client.get_public_key()
+
+        inverters = await client.all_inverters(public_key)
+        solar = await client.solar(public_key)
+        account = await client.account(public_key)
         print(inverters)
         print(solar)
         print(account)

--- a/test_output.py
+++ b/test_output.py
@@ -9,18 +9,22 @@ from autarco import Account, Autarco, Inverter, Solar
 async def main():
     """Test."""
     async with Autarco(  # noqa: S106
-        public_key="123456789",
-        username="test@autarco.com",
-        password="test",
+        email="test@autarco.com",
+        password="password",
     ) as autarco:
-        inverters: Inverter = await autarco.all_inverters()
-        solar: Solar = await autarco.solar()
-        account: Account = await autarco.account()
+        public_key = await autarco.get_public_key()
+
+        inverters: dict[str, Inverter] = await autarco.all_inverters(public_key)
+        solar: Solar = await autarco.solar(public_key)
+        account: Account = await autarco.account(public_key)
+
+        print(f"Public key: {public_key}")
+        print()
 
         print("--- INVERTER(S) ---")
         print(inverters)
         print()
-        for item in inverters:
+        for item in inverters.values():
             print(item)
         print()
 

--- a/tests/fixtures/public_key.json
+++ b/tests/fixtures/public_key.json
@@ -1,0 +1,6 @@
+[
+    {
+        "public_key": "sd6fv516",
+        "name": "Autarco Integration"
+    }
+]

--- a/tests/test_autarco.py
+++ b/tests/test_autarco.py
@@ -32,8 +32,7 @@ async def test_json_request(aresponses):
     )
     async with aiohttp.ClientSession() as session:
         client = Autarco(  # noqa: S106
-            public_key="fake_key",
-            username="autarco",
+            email="test@autarco.com",
             password="energy",
             session=session,
         )
@@ -55,7 +54,7 @@ async def test_internal_session(aresponses):
         ),
     )
     async with Autarco(  # noqa: S106
-        public_key="fake_key", username="autarco", password="energy"
+        email="test@autarco.com", password="energy"
     ) as autarco:
         await autarco._request("test")
 
@@ -74,8 +73,7 @@ async def test_timeout(aresponses):
 
     async with aiohttp.ClientSession() as session:
         client = Autarco(  # noqa: S106
-            public_key="fake_key",
-            username="autarco",
+            email="test@autarco.com",
             password="energy",
             session=session,
             request_timeout=0.1,
@@ -99,8 +97,7 @@ async def test_content_type(aresponses):
 
     async with aiohttp.ClientSession() as session:
         client = Autarco(  # noqa: S106
-            public_key="fake_key",
-            username="autarco",
+            email="test@autarco.com",
             password="energy",
             session=session,
         )
@@ -113,8 +110,7 @@ async def test_client_error():
     """Test request client error from Autarco API."""
     async with aiohttp.ClientSession() as session:
         client = Autarco(  # noqa: S106
-            public_key="fake_key",
-            username="autarco",
+            email="test@autarco.com",
             password="energy",
             session=session,
         )
@@ -136,8 +132,7 @@ async def test_http_error400(aresponses):
 
     async with aiohttp.ClientSession() as session:
         client = Autarco(  # noqa: S106
-            public_key="fake_key",
-            username="autarco",
+            email="test@autarco.com",
             password="energy",
             session=session,
         )
@@ -157,8 +152,7 @@ async def test_http_error401(aresponses):
 
     async with aiohttp.ClientSession() as session:
         client = Autarco(  # noqa: S106
-            public_key="fake_key",
-            username="autarco",
+            email="test@autarco.com",
             password="energy",
             session=session,
         )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,7 @@
 """Test the models."""
 import aiohttp
 import pytest
+from aresponses import ResponsesMockServer
 
 from autarco import Account, Autarco, Inverter, Solar
 
@@ -8,7 +9,7 @@ from . import load_fixtures
 
 
 @pytest.mark.asyncio
-async def test_all_inverters(aresponses):
+async def test_all_inverters(aresponses: ResponsesMockServer) -> None:
     """Test request from a Autarco API - Inverter object."""
     aresponses.add(
         "my.autarco.com",
@@ -23,14 +24,15 @@ async def test_all_inverters(aresponses):
 
     async with aiohttp.ClientSession() as session:
         client = Autarco(  # noqa: S106
-            public_key="fake_key",
-            username="autarco",
+            email="test@autarco.com",
             password="energy",
             session=session,
         )
-        inverters: Inverter = await client.all_inverters()
+        inverters: dict[str, Inverter] = await client.all_inverters(
+            public_key="fake_key"
+        )
         assert inverters is not None
-        for item in inverters:
+        for item in inverters.values():
             assert item.serial_number
             assert item.out_ac_power == 100
             assert item.out_ac_energy_total
@@ -39,7 +41,7 @@ async def test_all_inverters(aresponses):
 
 
 @pytest.mark.asyncio
-async def test_solar(aresponses):
+async def test_solar(aresponses: ResponsesMockServer) -> None:
     """Test request from a Autarco API - Solar object."""
     aresponses.add(
         "my.autarco.com",
@@ -54,12 +56,11 @@ async def test_solar(aresponses):
 
     async with aiohttp.ClientSession() as session:
         client = Autarco(  # noqa: S106
-            public_key="fake_key",
-            username="autarco",
+            email="test@autarco.com",
             password="energy",
             session=session,
         )
-        solar: Solar = await client.solar()
+        solar: Solar = await client.solar(public_key="fake_key")
         assert solar is not None
         assert solar.power_production == 200
         assert solar.energy_production_today == 4
@@ -68,7 +69,7 @@ async def test_solar(aresponses):
 
 
 @pytest.mark.asyncio
-async def test_account(aresponses):
+async def test_account(aresponses: ResponsesMockServer) -> None:
     """Test request from a Autarco API - Account object."""
     aresponses.add(
         "my.autarco.com",
@@ -83,12 +84,11 @@ async def test_account(aresponses):
 
     async with aiohttp.ClientSession() as session:
         client = Autarco(  # noqa: S106
-            public_key="fake_key",
-            username="autarco",
+            email="test@autarco.com",
             password="energy",
             session=session,
         )
-        account: Account = await client.account()
+        account: Account = await client.account(public_key="fake_key")
         assert account is not None
         assert account.public_key == "sd6fv516"
         assert account.name == "Autarco Integration"
@@ -96,3 +96,28 @@ async def test_account(aresponses):
         assert account.state == "www"
         assert account.country == "Online"
         assert account.timezone == "Europe/Amsterdam"
+
+
+@pytest.mark.asyncio
+async def test_get_public_key(aresponses: ResponsesMockServer) -> None:
+    """Test request from a Autarco API - get_public_key."""
+    aresponses.add(
+        "my.autarco.com",
+        "/api/site/",
+        "GET",
+        aresponses.Response(
+            text=load_fixtures("public_key.json"),
+            status=200,
+            headers={"Content-Type": "application/json; charset=utf-8"},
+        ),
+    )
+
+    async with aiohttp.ClientSession() as session:
+        client = Autarco(  # noqa: S106
+            email="test@autarco.com",
+            password="energy",
+            session=session,
+        )
+        public_key = await client.get_public_key()
+        assert public_key is not None
+        assert public_key == "sd6fv516"


### PR DESCRIPTION
From now on you don't have to search for what your public_key is, because there is a separate function that can retrieve it. In addition, it is not the username but your email that you enter when you log in to the Autarco portal.