### PR TITLE
Remove setuptools from build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,5 +158,5 @@ paths = ["autarco"]
 verbose = true
 
 [build-system]
-requires = ["setuptools", "poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
The setuptools dependency should be unnecessary to build the package.