### PR TITLE
Fix bug when dt_created is null

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,10 +138,10 @@ With all the sites you have access to.
 | `public_key`            | `str`  | The public key of the site.                                                   |
 | `name`                  | `str`  | The name of the site.                                                         |
 | `address`               | `dict` | The address of the site. (**street**, **zip code**, **city** and **country**) |
-| `timezone`              | `str`  | The timezone of the site.                                                     |
-| `created_at`            | `date` | The creation date of the site.                                                |
 | `has_consumption_meter` | `bool` | If the site has a consumption meter.                                          |
+| `timezone`              | `str`  | The timezone of the site.                                                     |
 | `has_battery`           | `bool` | If the site has a battery.                                                    |
+| `created_at`            | `date` | The creation date of the site. (default: None)                                |
 
 ### Statistics
 

--- a/src/autarco/models.py
+++ b/src/autarco/models.py
@@ -165,10 +165,12 @@ class Site(DataClassORJSONMixin):
     name: str
     address: Address
 
-    timezone: str
-    created_at: date = field(metadata=field_options(alias="dt_created"))
     has_consumption_meter: bool
     has_battery: bool
+    timezone: str
+    created_at: date | None = field(
+        metadata=field_options(alias="dt_created"), default=None
+    )
 
 
 @dataclass

--- a/tests/__snapshots__/test_models.ambr
+++ b/tests/__snapshots__/test_models.ambr
@@ -138,8 +138,11 @@
     '987654321234': Inverter(serial_number='987654321234', out_ac_power=100, out_ac_energy_total=3607, grid_turned_off=False, health='OK'),
   })
 # ---
+# name: test_get_old_site
+  Site(public_key='blabla', name='My Autarco solar installation', address=Address(street='Streetname 00', zip_code='1111 AA', city='Valkenswaard', country='Nederland'), has_consumption_meter=False, has_battery=False, timezone='Europe/Amsterdam', created_at=None)
+# ---
 # name: test_get_site
-  Site(public_key='blabla', name='My Autarco solar installation', address=Address(street='Streetname 00', zip_code='1111 AA', city='Valkenswaard', country='Nederland'), timezone='Europe/Amsterdam', created_at=datetime.date(2023, 5, 15), has_consumption_meter=False, has_battery=False)
+  Site(public_key='blabla', name='My Autarco solar installation', address=Address(street='Streetname 00', zip_code='1111 AA', city='Valkenswaard', country='Nederland'), has_consumption_meter=False, has_battery=False, timezone='Europe/Amsterdam', created_at=datetime.date(2023, 5, 15))
 # ---
 # name: test_get_solar
   Solar(power_production=3323, energy_production_today=8, energy_production_month=114, energy_production_total=29176)

--- a/tests/fixtures/old_site.json
+++ b/tests/fixtures/old_site.json
@@ -1,0 +1,41 @@
+{
+  "public_key": "blabla",
+  "name": "My Autarco solar installation",
+  "address": {
+    "address_line_1": "Streetname 00",
+    "postcode": "1111 AA",
+    "city": "Valkenswaard",
+    "country": "Nederland"
+  },
+  "timezone": "Europe/Amsterdam",
+  "dt_created": null,
+  "dt_updated": "2023-05-15",
+  "has_consumption_meter": false,
+  "has_battery": false,
+  "systems": [
+    {
+      "retailer": "Kiggen",
+      "nominal_power": 4800,
+      "dt_created": "2023-05-15",
+      "dt_updated": "2023-05-15",
+      "inverters": {
+        "1802040231290027": {
+          "serial_number": "1802040231290027",
+          "variant_code": "S2.MX4600-MIII.1",
+          "dt_installed": "2023-05-15",
+          "dt_uninstalled": null
+        }
+      },
+      "layout": [
+        {
+          "qty": 12,
+          "type": "S1.MHJ400B",
+          "pitch": 35,
+          "azimuth": -42
+        }
+      ],
+      "guarantee": null,
+      "dt_installed": "2023-05-15"
+    }
+  ]
+}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -125,6 +125,26 @@ async def test_get_site(
     assert site == snapshot
 
 
+async def test_get_old_site(
+    aresponses: ResponsesMockServer,
+    snapshot: SnapshotAssertion,
+    autarco_client: Autarco,
+) -> None:
+    """Test request from a Autarco API - old Site object."""
+    aresponses.add(
+        "my.autarco.com",
+        "/api/site/fake_key/",
+        "GET",
+        aresponses.Response(
+            text=load_fixtures("old_site.json"),
+            status=200,
+            headers={"Content-Type": "application/json; charset=utf-8"},
+        ),
+    )
+    site: Site = await autarco_client.get_site(public_key="fake_key")
+    assert site == snapshot
+
+
 async def test_get_account(
     aresponses: ResponsesMockServer,
     snapshot: SnapshotAssertion,


### PR DESCRIPTION
## Proposed change
<!--
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the
    additional information section.
-->
This fixes an issue when fetching old sites, where Autarco apparently sets the **dt_created** value to `000-00-00 00:00:00` or `null`.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Go over all the following points, and put an `x` in all the boxes that apply.
    If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the documentation if needed.
- [X] I have updated the tests if needed.
